### PR TITLE
Remove unnecessary use of cat, printf, and base64

### DIFF
--- a/dossier
+++ b/dossier
@@ -39,7 +39,7 @@ sub_install() {
         gum confirm "Are you sure you want to install these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
         for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
-                printf %s "${row}" | base64 --decode | jq -r "${1}"
+                base64 --decode <<< "${row}" | jq -r "${1}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -59,7 +59,7 @@ sub_install() {
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
         for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
             _jq() {
-                printf %s "${row}" | base64 --decode | jq -r "${1}"
+                base64 --decode <<< "${row}" | jq -r "${1}"
             }
             COMMAND="$(_jq '.command')"
             MESSAGE="$(_jq '.message')"
@@ -78,7 +78,7 @@ sub_preview() {
     if [ -f "./dossier.config.json" ]; then
         for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
-                printf %s "${row}" | base64 --decode | jq -r "${1}"
+                base64 --decode <<< "${row}" | jq -r "${1}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -107,7 +107,7 @@ sub_reinstall() {
         gum confirm "Are you sure you want to reinstall these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
         for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
                 _jq() {
-                    printf %s "${row}" | base64 --decode | jq -r "${1}"
+                    base64 --decode <<< "${row}" | jq -r "${1}"
                 }
                 NAME="$(_jq '.name')"
                 LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -119,7 +119,7 @@ sub_reinstall() {
         done &&
         for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
-                printf %s "${row}" | base64 --decode | jq -r "${1}"
+                base64 --decode <<< "${row}" | jq -r "${1}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -137,7 +137,7 @@ sub_reinstall() {
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
         for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
             _jq() {
-                printf %s "${row}" | base64 --decode | jq -r "${1}"
+                base64 --decode <<< "${row}" | jq -r "${1}"
             }
             COMMAND="$(_jq '.command')"
             MESSAGE="$(_jq '.message')"
@@ -157,7 +157,7 @@ sub_uninstall() {
      This could lead to a broken desktop!" &&
     for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
         _jq() {
-            printf %s "${row}" | base64 --decode | jq -r "${1}"
+            base64 --decode <<< "${row}" | jq -r "${1}"
         }
         NAME="$(_jq '.name')"
         LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"

--- a/dossier
+++ b/dossier
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-# shellcheck source=/dev/null
-# shellcheck disable=2002
 
 ProgName=$(basename "$0")
 Version="0.0.3"

--- a/dossier
+++ b/dossier
@@ -2,7 +2,7 @@
 
 ProgName=$(basename "$0")
 Version="0.0.3"
-  
+
 sub_help(){
     echo "Usage: $ProgName <subcommand>"
     echo "Subcommands:"
@@ -29,15 +29,16 @@ sub_v() {
 }
 
 sub_install() {
-    if [ -f "$HOME/.config/dossier.lock" ]; then 
+    if [ -f "$HOME/.config/dossier.lock" ]; then
         echo "Dossier has already installed your dotfiles! Please use dossier uninstall"
         exit
     fi
     if [ -f "./dossier.config.json" ]; then
+        IFS=$'\n'
         gum confirm "Are you sure you want to install these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
-        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
+        for row in $(jq -Mrc '.files[]' < dossier.config.json); do
             _jq() {
-                base64 --decode <<< "${row}" | jq -r "${1}"
+                jq -Mrc "${1}" <<< "${row}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -55,15 +56,15 @@ sub_install() {
                 fi
             fi
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
-        for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
+        for row in $(jq -Mrc '.commands[]' < dossier.config.json); do
             _jq() {
-                base64 --decode <<< "${row}" | jq -r "${1}"
+                jq -Mrc "${1}" <<< "${row}"
             }
             COMMAND="$(_jq '.command')"
             MESSAGE="$(_jq '.message')"
             gum spin --title "$MESSAGE" -s line -- bash -c "$COMMAND" && echo -e "\e[38;5;114m$(_jq '.donemessage')\e[0m"
         done && mkdir -p "$HOME/.config/"
-    else 
+    else
         echo "This directory does not have a dossier config!"
     fi
 }
@@ -74,9 +75,10 @@ sub_i() {
 
 sub_preview() {
     if [ -f "./dossier.config.json" ]; then
-        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
+        IFS=$'\n'
+        for row in $(jq -Mrc '.files[]' < dossier.config.json); do
             _jq() {
-                base64 --decode <<< "${row}" | jq -r "${1}"
+                jq -Mrc "${1}" <<< "${row}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -91,7 +93,7 @@ sub_preview() {
             fi
         done &&
         mkdir -p "$HOME/.config/"
-    else 
+    else
         echo "This directory does not have a dossier config!"
     fi
 }
@@ -102,10 +104,11 @@ sub_p() {
 
 sub_reinstall() {
     if [ -f "./dossier.config.json" ]; then
+        IFS=$'\n'
         gum confirm "Are you sure you want to reinstall these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
-        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
+        for row in $(jq -Mrc '.files[]' < dossier.config.json); do
                 _jq() {
-                    base64 --decode <<< "${row}" | jq -r "${1}"
+                    jq -Mrc "${1}" <<< "${row}"
                 }
                 NAME="$(_jq '.name')"
                 LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -115,9 +118,9 @@ sub_reinstall() {
                 rm -f "${LOCATION:?}"
             fi
         done &&
-        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
+        for row in $(jq -Mrc '.files[]' < dossier.config.json); do
             _jq() {
-                base64 --decode <<< "${row}" | jq -r "${1}"
+                jq -Mrc "${1}" <<< "${row}"
             }
             NAME="$(_jq '.name')"
             LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"
@@ -133,29 +136,30 @@ sub_reinstall() {
                 fi
             fi
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
-        for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
+        for row in $(jq -Mrc '.commands[]' < dossier.config.json); do
             _jq() {
-                base64 --decode <<< "${row}" | jq -r "${1}"
+                jq -Mrc "${1}" <<< "${row}"
             }
             COMMAND="$(_jq '.command')"
             MESSAGE="$(_jq '.message')"
             gum spin --title "$MESSAGE" -s line -- bash -c "$COMMAND" && echo -e "\e[38;5;114m$(_jq '.donemessage')\e[0m"
         done && mkdir -p "$HOME/.config/"
-    else 
+    else
         echo "This directory does not have a dossier config!"
     fi
 }
-  
+
 sub_uninstall() {
-    if [ ! -f "$HOME/.config/dossier.lock" ]; then 
+    if [ ! -f "$HOME/.config/dossier.lock" ]; then
         echo "Dossier hasn't installed your dotfiles yet!"
         exit
     fi
+    IFS=$'\n'
     gum confirm "Are you sure you want to uninstall these dotfiles?
      This could lead to a broken desktop!" &&
-    for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
+    for row in $(jq -Mrc '.files[]' < dossier.config.json); do
         _jq() {
-            base64 --decode <<< "${row}" | jq -r "${1}"
+            jq -Mrc "${1}" <<< "${row}"
         }
         NAME="$(_jq '.name')"
         LOCATION="$(_jq '.location' | sed "s|^~|$HOME|")"

--- a/dossier
+++ b/dossier
@@ -37,7 +37,7 @@ sub_install() {
     fi
     if [ -f "./dossier.config.json" ]; then
         gum confirm "Are you sure you want to install these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
-        for row in $(cat dossier.config.json | jq -r '.files[] | @base64'); do
+        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
                 printf %s "${row}" | base64 --decode | jq -r "${1}"
             }
@@ -57,7 +57,7 @@ sub_install() {
                 fi
             fi
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
-        for row in $(cat dossier.config.json | jq -r '.commands[] | @base64'); do
+        for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
             _jq() {
                 printf %s "${row}" | base64 --decode | jq -r "${1}"
             }
@@ -76,7 +76,7 @@ sub_i() {
 
 sub_preview() {
     if [ -f "./dossier.config.json" ]; then
-        for row in $(cat dossier.config.json | jq -r '.files[] | @base64'); do
+        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
                 printf %s "${row}" | base64 --decode | jq -r "${1}"
             }
@@ -105,7 +105,7 @@ sub_p() {
 sub_reinstall() {
     if [ -f "./dossier.config.json" ]; then
         gum confirm "Are you sure you want to reinstall these dotfiles?" && mkdir -p "$HOME/.config/dossier" && touch "$HOME/.config/dossier.lock" &&
-        for row in $(cat dossier.config.json | jq -r '.files[] | @base64'); do
+        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
                 _jq() {
                     printf %s "${row}" | base64 --decode | jq -r "${1}"
                 }
@@ -117,7 +117,7 @@ sub_reinstall() {
                 rm -f "${LOCATION:?}"
             fi
         done &&
-        for row in $(cat dossier.config.json | jq -r '.files[] | @base64'); do
+        for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
             _jq() {
                 printf %s "${row}" | base64 --decode | jq -r "${1}"
             }
@@ -135,7 +135,7 @@ sub_reinstall() {
                 fi
             fi
         done && echo -e "\e[38;5;114mAll links have been set up\e[0m" &&
-        for row in $(cat dossier.config.json | jq -r '.commands[] | @base64'); do
+        for row in $(jq -r '.commands[] | @base64' < dossier.config.json); do
             _jq() {
                 printf %s "${row}" | base64 --decode | jq -r "${1}"
             }
@@ -155,7 +155,7 @@ sub_uninstall() {
     fi
     gum confirm "Are you sure you want to uninstall these dotfiles?
      This could lead to a broken desktop!" &&
-    for row in $(cat dossier.config.json | jq -r '.files[] | @base64'); do
+    for row in $(jq -r '.files[] | @base64' < dossier.config.json); do
         _jq() {
             printf %s "${row}" | base64 --decode | jq -r "${1}"
         }
@@ -178,7 +178,7 @@ sub_add() {
             echo "You need to specify what file to track!"
             exit
         fi
-        EXISTS=$(cat dossier.config.json | jq ".files[] | select(.name == \"$NAME\")")
+        EXISTS=$(jq ".files[] | select(.name == \"$NAME\")" < dossier.config.json)
         if [ -n "$EXISTS" ]; then
             echo "That file has already been added!"
             exit
@@ -194,7 +194,7 @@ sub_add() {
             echo "You need to specify if this is a file or folder!"
             exit
         fi
-        cat dossier.config.json | jq ".files += [{\"name\": \"$NAME\", \"location\": \"$LOCATION\", \"type\": \"$FILEFOLDER\"}]" | tee 'dossier.config.json' &>/dev/null
+        jq ".files += [{\"name\": \"$NAME\", \"location\": \"$LOCATION\", \"type\": \"$FILEFOLDER\"}]" < dossier.config.json | tee 'dossier.config.json' &>/dev/null
         if [ "$FILEFOLDER" == 'same' ]; then
             echo -e "\e[38;5;212m${PWD}/${NAME} will be symlinked to ${LOCATION}/${NAME} next time you install!\e[0m"
         else
@@ -216,7 +216,7 @@ sub_remove() {
             echo "You need to specify what file to stop tracking!"
             exit
         fi
-        cat dossier.config.json | jq "del(.files[] | select(.name == \"$NAME\"))" | tee 'dossier.config.json' &>/dev/null
+        jq "del(.files[] | select(.name == \"$NAME\"))" < dossier.config.json | tee 'dossier.config.json' &>/dev/null
     else
         echo "This directory does not have a dossier config!"
     fi

--- a/dossier.config.json
+++ b/dossier.config.json
@@ -1,0 +1,86 @@
+{
+  "files": [
+    {
+      "name": "neovim",
+      "location": "~/.config/nvim",
+      "type": "different"
+    },
+    {
+      "name": "zsh/zshrc",
+      "location": "~/.zshrc",
+      "type": "different"
+    },
+    {
+      "name": "Xresources",
+      "location": "~/.Xresources",
+      "type": "different"
+    },
+    {
+      "name": "zsh/aliasrc",
+      "location": "~/.aliasrc",
+      "type": "different"
+    },
+    {
+      "name": "gitconfig",
+      "location": "~/.gitconfig",
+      "type": "different"
+    },
+    {
+      "name": "main.i3config",
+      "location": "~/.config/i3/config",
+      "type": "different"
+    },
+    {
+      "name": "polybar",
+      "location": "~/.config",
+      "type": "same"
+    },
+    {
+      "name": "kitty",
+      "location": "~/.config",
+      "type": "same"
+    },
+    {
+      "name": "rofi",
+      "location": "~/.config",
+      "type": "same"
+    },
+    {
+      "name": "rofithemes",
+      "location": "~/.local/share/rofi/themes",
+      "type": "different"
+    },
+    {
+      "name": "dunst",
+      "location": "~/.config",
+      "type": "same"
+    },
+    {
+      "name": "powercordthemes",
+      "location": "~/.dotfiles/powercord/src/Powercord/themes",
+      "type": "different"
+    },
+    {
+      "name": "powercordplugins",
+      "location": "~/.dotfiles/powercord/src/Powercord/plugins",
+      "type": "different"
+    },
+    {
+      "name": "picom.conf",
+      "location": "~/.config",
+      "type": "same"
+    },
+    {
+      "name": "theming/catppuccin-spotify-tui/mocha.yml",
+      "location": "~/.config/spotify-tui/config.yaml",
+      "type": "different"
+    }
+  ],
+  "commands": [
+    {
+      "command": "git submodule update --init --recursive",
+      "message": "Installing submodules",
+      "donemessage": "Installed submodules"
+    }
+  ]
+}


### PR DESCRIPTION
- Instead of `cat foo | bar`, use `bar < foo`
- Instead of `printf %s "${foo}" | bar`, use `bar <<< "${foo}"`

This also fixes the issues in shellcheck, so I've removed the lines that disable shellcheck